### PR TITLE
Disallow a choice expression where a non-final subexpression always matches

### DIFF
--- a/check.go
+++ b/check.go
@@ -253,7 +253,10 @@ func (e *Choice) check(ctx ctx, valueUsed bool, errs *Errors) {
 		sub.check(subCtx, valueUsed, errs)
 	}
 	t := e.Exprs[0].Type()
-	for _, sub := range e.Exprs {
+	for i, sub := range e.Exprs {
+		if i < len(e.Exprs) - 1 && !sub.CanFail() {
+			errs.add(e, "non-final choice subexpression always matches: %s", sub)
+		}
 		if got := sub.Type(); *genActions && valueUsed && got != t && got != "" && t != "" {
 			errs.add(sub, "type mismatch: got %s, expected %s", got, t)
 		}

--- a/check_test.go
+++ b/check_test.go
@@ -253,6 +253,15 @@ G <- [fgh]*`,
 			err: "^test.file:1.8,1.27: type mismatch: got int, expected string\n" +
 				"test.file:2.16,2.35: type mismatch: got int, expected string$",
 		},
+		{
+			name: "choice non-final subexpression that always matches is an error",
+			in:   `A <- "B"? / "C"`,
+			err:  "non-final choice subexpression always matches:",
+		},
+		{
+			name: "choice final subexpression may always match",
+			in:   `A <- "B" / "C"?`,
+		},
 	}
 	for _, test := range tests {
 		test := test


### PR DESCRIPTION
None of the subexpressions following it could ever match, so it's certainly a grammar error. But also, the code generated for such a case does not compile correctly :)